### PR TITLE
Reduce carousel dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -262,8 +262,8 @@ footer {
 .carousel {
   position: relative;
   width: 100%;
-  max-width: 800px;
-  aspect-ratio: 4/3;       /* altura automática según el ancho */
+  max-width: 600px;
+  aspect-ratio: 16/9;       /* altura automática según el ancho */
   margin: 20px auto;
   overflow: hidden;
   border: 5px solid #003366;


### PR DESCRIPTION
## Summary
- Limit homepage carousel width to 600px for smaller display footprint
- Use 16:9 aspect ratio for shorter height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fdf3a922c8324a5782907d1f87d52