### PR TITLE
Add Academia Hidabo CTA below carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,11 @@
       <img src="img/foto6.jpeg" alt="HIDABO 6" class="carousel-image">
       <img src="img/foto7.jpeg" alt="HIDABO 7" class="carousel-image">
       <img src="img/foto8.jpeg" alt="HIDABO 8" class="carousel-image">
-    </div>
-  </section>
+      </div>
+      <div class="academia-cta">
+        <a href="fotos.html" class="btn-academia">Ver Academia Hidabo</a>
+      </div>
+    </section>
 
   <section id="productos" class="section">
     <h2>Nuestros Productos</h2>

--- a/style.css
+++ b/style.css
@@ -305,3 +305,24 @@ footer {
     aspect-ratio: 1/1;   /* carrusel cuadrado en móvil */
   }
 }
+
+/* --- CTA ACADEMIA --- */
+.academia-cta {
+  text-align: center;
+  margin-top: 20px;
+}
+
+.btn-academia {
+  display: inline-block;
+  padding: 10px 20px;
+  background-color: #ff6600;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 5px;
+  font-weight: bold;
+  transition: background-color 0.3s ease;
+}
+
+.btn-academia:hover {
+  background-color: #e65500;
+}


### PR DESCRIPTION
## Summary
- Add a centered "Academia Hidabo" call-to-action button directly below the homepage carousel.
- Style the new button with brand-accent colors and hover transition for better visibility.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689111d3c3308324b0df43db39c6f8c3