### PR TITLE
Add React carousel to Quiénes Somos section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite

--- a/index.html
+++ b/index.html
@@ -32,16 +32,7 @@
       <p><strong>Trabajamos codo a codo con los productores</strong>, ofreciendo asesoría técnica, atención personalizada y logística propia para garantizar que cada solución llegue a tiempo y en forma.</p>
       <p>Nuestra filosofía de crecimiento siempre fue simple: <strong>Cumplir con el productor.</strong></p>
     </div>
-    <div class="carousel">
-      <img src="img/foto1.jpeg" alt="HIDABO 1" class="carousel-image active">
-      <img src="img/foto2.jpeg" alt="HIDABO 2" class="carousel-image">
-      <img src="img/foto3.jpeg" alt="HIDABO 3" class="carousel-image">
-      <img src="img/foto4.jpeg" alt="HIDABO 4" class="carousel-image">
-      <img src="img/foto5.jpeg" alt="HIDABO 5" class="carousel-image">
-      <img src="img/foto6.jpeg" alt="HIDABO 6" class="carousel-image">
-      <img src="img/foto7.jpeg" alt="HIDABO 7" class="carousel-image">
-      <img src="img/foto8.jpeg" alt="HIDABO 8" class="carousel-image">
-      </div>
+    <div id="carousel-root"></div>
       <div class="academia-cta">
         <a href="fotos.html" class="btn-academia">Ver Academia Hidabo</a>
       </div>
@@ -94,18 +85,6 @@
   <footer>
     &copy; 2025 HIDABO S.R.L. - Todos los derechos reservados.
   </footer>
-  <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      const imgs = document.querySelectorAll("#quienes .carousel-image");
-      let current = 0;
-      if (imgs.length > 0) {
-        setInterval(function() {
-          imgs[current].classList.remove("active");
-          current = (current + 1) % imgs.length;
-          imgs[current].classList.add("active");
-        }, 3000);
-      }
-    });
-  </script>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "swiper": "^11.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -1,0 +1,22 @@
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Autoplay, Pagination } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+export default function Carousel({ images = [] }) {
+  return (
+    <Swiper
+      modules={[Autoplay, Pagination]}
+      autoplay={{ delay: 3000, disableOnInteraction: false }}
+      loop
+      pagination={{ clickable: true }}
+      className="carousel"
+    >
+      {images.map((src, idx) => (
+        <SwiperSlide key={idx}>
+          <img src={src} alt={`Slide ${idx + 1}`} />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Carousel from './components/Carousel.jsx';
+
+const images = [
+  '/img/foto1.jpeg',
+  '/img/foto2.jpeg',
+  '/img/foto3.jpeg',
+  '/img/foto4.jpeg',
+  '/img/foto5.jpeg',
+  '/img/foto6.jpeg',
+  '/img/foto7.jpeg',
+  '/img/foto8.jpeg',
+];
+
+ReactDOM.createRoot(document.getElementById('carousel-root')).render(
+  <React.StrictMode>
+    <Carousel images={images} />
+  </React.StrictMode>
+);

--- a/style.css
+++ b/style.css
@@ -271,34 +271,12 @@ footer {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }
 
-.carousel-image {
-  position: absolute;
-  top: 0;
-  left: 0;
+.carousel img {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  opacity: 0;
-  transform: scale(1);
-  transition: opacity 1s ease, transform 3s ease;
 }
 
-.carousel-image.active {
-  opacity: 1;
-  animation: zoom 3s ease-in-out;
-}
-
-@keyframes zoom {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
 
 @media (max-width: 768px) {
   .carousel {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- Set up Vite + React tooling and configuration
- Implement Swiper-based Carousel component and mount it in the "Quiénes Somos" section
- Adapt global styles for the new carousel

## Testing
- `npm run build` (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_68911ada9a348324b9df0df997c53d77