### PR TITLE
Fix carousel image paths for production build

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,15 +2,25 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Carousel from './components/Carousel.jsx';
 
+// Importar las imágenes para que Vite genere las rutas correctas en producción
+import foto1 from '../img/foto1.jpeg';
+import foto2 from '../img/foto2.jpeg';
+import foto3 from '../img/foto3.jpeg';
+import foto4 from '../img/foto4.jpeg';
+import foto5 from '../img/foto5.jpeg';
+import foto6 from '../img/foto6.jpeg';
+import foto7 from '../img/foto7.jpeg';
+import foto8 from '../img/foto8.jpeg';
+
 const images = [
-  '/img/foto1.jpeg',
-  '/img/foto2.jpeg',
-  '/img/foto3.jpeg',
-  '/img/foto4.jpeg',
-  '/img/foto5.jpeg',
-  '/img/foto6.jpeg',
-  '/img/foto7.jpeg',
-  '/img/foto8.jpeg',
+  foto1,
+  foto2,
+  foto3,
+  foto4,
+  foto5,
+  foto6,
+  foto7,
+  foto8,
 ];
 
 ReactDOM.createRoot(document.getElementById('carousel-root')).render(


### PR DESCRIPTION
## Summary
- import carousel images in `src/main.jsx` so Vite generates correct paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893dd2e91a883249cf61fda0019ee2b