### PR TITLE
feat: smooth carousel transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,9 +85,13 @@
       if (slides.length > 0) {
         slides[index].classList.add('active');
         setInterval(() => {
-          slides[index].classList.remove('active');
+          const current = slides[index];
           index = (index + 1) % slides.length;
-          slides[index].classList.add('active');
+          const next = slides[index];
+          next.classList.add('active');
+          setTimeout(() => {
+            current.classList.remove('active');
+          }, 100);
         }, 2000);
       }
     });

--- a/style.css
+++ b/style.css
@@ -106,20 +106,18 @@ nav a:hover {
 }
 
 .carousel img {
-  max-width: 100%;
-  max-height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
-  display: none;
+  opacity: 0;
+  transition: opacity 1s ease-in-out;
 }
 
 .carousel img.active {
-  display: block;
-  animation: fade 1s ease-in-out;
-}
-
-@keyframes fade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  opacity: 1;
 }
 
 /* --- PRODUCTOS --- */


### PR DESCRIPTION
## Summary
- avoid white flash by overlaying carousel images and fading via opacity transitions
- delay removal of `active` class until next slide starts

## Testing
- `npm test` (fails: enoent package.json)


------
https://chatgpt.com/codex/tasks/task_e_689aa26c2f04832499bf45f5f359843d